### PR TITLE
feat: respond with status code 200 on analytics endpoint

### DIFF
--- a/dist/turboServer/index.js
+++ b/dist/turboServer/index.js
@@ -33376,6 +33376,10 @@ async function startServer() {
             res.send('OK');
         });
     });
+    app.post('/v8/artifacts/events', (req, res) => {
+        // Analytics endpoint, just ignore it
+        res.status(200).send();
+    });
     app.disable('etag').listen(port, () => {
         console.log(`Cache dir: ${cacheDir}`);
         console.log(`Local Turbo server is listening at http://127.0.0.1:${port}`);

--- a/src/turboServer.ts
+++ b/src/turboServer.ts
@@ -85,6 +85,11 @@ async function startServer() {
     });
   });
 
+  app.post('/v8/artifacts/events', (req, res) => {
+    // Analytics endpoint, just ignore it
+    res.status(200).send();
+  });
+
   app.disable('etag').listen(port, () => {
     console.log(`Cache dir: ${cacheDir}`);
     console.log(`Local Turbo server is listening at http://127.0.0.1:${port}`);


### PR DESCRIPTION
As discussed in #9, this PR adds a stub for the analytics endpoint so turbo stops logging errors when run with the `-vv` flag. 