### PR TITLE
feat: cache `listArtifacts()` results between GETs

### DIFF
--- a/src/utils/artifactApi.ts
+++ b/src/utils/artifactApi.ts
@@ -2,7 +2,7 @@ import { getInput } from '@actions/core';
 import { Axios } from 'axios';
 import { Inputs } from './constants';
 
-interface IArtifactListResponse {
+export interface IArtifactListResponse {
   total_count: number;
   artifacts?: Array<{
     id: number;


### PR DESCRIPTION
As discussed, this PR adds caching for the `listArtifacts()` call to avoid repeated GitHub API requests with the same result.