### PR TITLE
feat: check if artifact exists locally before attempting download

### DIFF
--- a/dist/turboServer/index.js
+++ b/dist/turboServer/index.js
@@ -33344,7 +33344,6 @@ async function startServer() {
     });
     app.get('/v8/artifacts/:artifactId', express_async_handler_default()(async (req, res) => {
         const { artifactId } = req.params;
-        const list = await artifactApi.listArtifacts();
         const filepath = external_path_default().join(cacheDir, `${artifactId}.gz`);
         if (!lib_default().pathExistsSync(filepath)) {
             console.log(`Artifact ${artifactId} not found locally, downloading it.`);

--- a/src/turboServer.ts
+++ b/src/turboServer.ts
@@ -37,7 +37,6 @@ async function startServer() {
     '/v8/artifacts/:artifactId',
     asyncHandler(async (req: any, res: any) => {
       const { artifactId } = req.params;
-      const list = await artifactApi.listArtifacts();
 
       const filepath = path.join(cacheDir, `${artifactId}.gz`);
 


### PR DESCRIPTION
And here's the 3rd part of what we discussed. This PR is based on #11. I can rebase it depending on what we do with #11.

The main point of this PR is to enable other means of persisting the turbo cache between jobs, and avoiding re-downloads when running tasks that re-check the cache for the same hash as previously.