### PR TITLE
Refactor logs

### DIFF
--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -19804,6 +19804,7 @@ var external_path_default = /*#__PURE__*/__nccwpck_require__.n(external_path_);
 ;// CONCATENATED MODULE: ./src/utils/constants.ts
 
 
+const DEFAULT_PORT = 9080;
 const cacheDir = external_path_default().join(process.env.RUNNER_TEMP || external_os_default().tmpdir(), 'turbo-cache');
 var States;
 (function (States) {

--- a/dist/starter/index.js
+++ b/dist/starter/index.js
@@ -5964,6 +5964,7 @@ var external_os_default = /*#__PURE__*/__nccwpck_require__.n(external_os_);
 ;// CONCATENATED MODULE: ./src/utils/constants.ts
 
 
+const DEFAULT_PORT = 9080;
 const cacheDir = external_path_default().join(process.env.RUNNER_TEMP || external_os_default().tmpdir(), 'turbo-cache');
 var States;
 (function (States) {

--- a/dist/turboServer/index.js
+++ b/dist/turboServer/index.js
@@ -33241,6 +33241,7 @@ var external_os_default = /*#__PURE__*/__nccwpck_require__.n(external_os_);
 ;// CONCATENATED MODULE: ./src/utils/constants.ts
 
 
+const DEFAULT_PORT = 9080;
 const cacheDir = external_path_default().join(process.env.RUNNER_TEMP || external_os_default().tmpdir(), 'turbo-cache');
 var States;
 (function (States) {
@@ -33324,7 +33325,7 @@ async function downloadArtifact(artifact, destFolder) {
 
 
 async function startServer() {
-    const port = process.env.PORT || 9080;
+    const port = process.env.PORT || DEFAULT_PORT;
     lib_default().ensureDirSync(cacheDir);
     const app = express_default()();
     const serverToken = (0,core.getInput)(Inputs.SERVER_TOKEN, {
@@ -33346,7 +33347,7 @@ async function startServer() {
         const { artifactId } = req.params;
         const filepath = external_path_default().join(cacheDir, `${artifactId}.gz`);
         if (!lib_default().pathExistsSync(filepath)) {
-            console.log(`Artifact ${artifactId} not found locally, downloading it.`);
+            console.log(`Artifact ${artifactId} not found locally, attempting to download it.`);
             if (!artifactList) {
                 // Cache the response for the runtime of the server.
                 // This avoids doing repeated requests with the same result.
@@ -33360,7 +33361,6 @@ async function startServer() {
                 else {
                     console.log(`Artifact ${artifactId} found.`);
                     await downloadArtifact(existingArtifact, cacheDir);
-                    console.log(`Artifact ${artifactId} downloaded successfully to ${cacheDir}/${artifactId}.gz.`);
                 }
             }
             if (!lib_default().pathExistsSync(filepath)) {

--- a/src/turboServer.ts
+++ b/src/turboServer.ts
@@ -4,11 +4,11 @@ import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
 import path from 'path';
 import { artifactApi, IArtifactListResponse } from './utils/artifactApi';
-import { cacheDir, Inputs } from './utils/constants';
+import { cacheDir, DEFAULT_PORT, Inputs } from './utils/constants';
 import { downloadArtifact } from './utils/downloadArtifact';
 
 async function startServer() {
-  const port = process.env.PORT || 9080;
+  const port = process.env.PORT || DEFAULT_PORT;
 
   fs.ensureDirSync(cacheDir);
 
@@ -41,9 +41,7 @@ async function startServer() {
       const filepath = path.join(cacheDir, `${artifactId}.gz`);
 
       if (!fs.pathExistsSync(filepath)) {
-        console.log(
-          `Artifact ${artifactId} not found locally, downloading it.`
-        );
+        console.log(`Artifact ${artifactId} not found locally, attempting to download it.`);
 
         if (!artifactList) {
           // Cache the response for the runtime of the server.
@@ -61,7 +59,6 @@ async function startServer() {
           } else {
             console.log(`Artifact ${artifactId} found.`);
             await downloadArtifact(existingArtifact, cacheDir);
-            console.log(`Artifact ${artifactId} downloaded successfully to ${cacheDir}/${artifactId}.gz.`);
           }
         }
 

--- a/src/utils/artifactApi.ts
+++ b/src/utils/artifactApi.ts
@@ -4,18 +4,20 @@ import { Inputs } from './constants';
 
 export interface IArtifactListResponse {
   total_count: number;
-  artifacts?: Array<{
-    id: number;
-    node_id: string;
-    name: string;
-    size_in_bytes: number;
-    url: string;
-    archive_download_url: string;
-    expired: boolean;
-    created_at: string;
-    updated_at: string;
-    expires_at: string;
-  }>;
+  artifacts?: Array<IArtifactResponse>;
+}
+
+export interface IArtifactResponse {
+  id: number;
+  node_id: string;
+  name: string;
+  size_in_bytes: number;
+  url: string;
+  archive_download_url: string;
+  expired: boolean;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
 }
 
 class ArtifactApi {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,8 @@
 import os from 'os';
 import path from 'path';
 
+export const DEFAULT_PORT = 9080
+
 export const cacheDir = path.join(
   process.env.RUNNER_TEMP || os.tmpdir(),
   'turbo-cache'

--- a/src/utils/downloadArtifact.ts
+++ b/src/utils/downloadArtifact.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import StreamZip from 'node-stream-zip';
 import path from 'path';
-import { artifactApi } from './artifactApi';
+import { artifactApi, IArtifactResponse } from './artifactApi';
 import os from 'os';
 
 const tempArchiveFolder = path.join(
@@ -9,7 +9,7 @@ const tempArchiveFolder = path.join(
   'turbo-archives'
 );
 
-export async function downloadArtifact(artifact, destFolder) {
+export async function downloadArtifact(artifact: IArtifactResponse, destFolder: string) {
   const { data } = await artifactApi.downloadArtifact(artifact.id);
   const archiveFilepath = path.join(tempArchiveFolder, `${artifact.name}.zip`);
 


### PR DESCRIPTION
There were a few things I found confusing looking at this project for my other PR, so I thought I'd suggest some very minor refactors. I kept it separate so you can just ignore this one if you like!

- If the artifact doesn't exist at all, the server still logs out "not found locally, downloading it" which sounded (to me) like it definitely does exist remotely. I slightly reworded it to make it clear that we're only looking for it remotely.
- I removed the log line about it being successfully downloaded because it looks like that may trigger in certain situations even if the process has failed. I looked at putting it in `downloadArtifact()` or `artifactApi.ts` but it seems like Axios will error if it fails, and there is already error logging if the compression fails, so it seemed both misleading and unnecessary.
- Made the default port a const as that (or a config file) is where I'd expect to find it.
- Type hinting for `downloadArtifact()` that I added when putting the above logline in there before I decided against it. Left it in just for helpfulness.