### PR TITLE
refactor(turboServer): use environment variables for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,31 @@ It's starts a local TurboRepo server (on port `9080`) and uses Github artifacts 
 ## Setup
 
 1. Add in your `workflow.yml` the following section **before** TurboRepo runs:
-```yaml
-- name: TurboRepo local server
-  uses: felixmosh/turborepo-gh-artifacts@v1
-  with:
-    repo-token: ${{ secrets.GITHUB_TOKEN }}
-```
+
+   ```yaml
+   - name: TurboRepo local server
+     uses: felixmosh/turborepo-gh-artifacts@v1
+     with:
+       repo-token: ${{ secrets.GITHUB_TOKEN }}
+   ```
+
 2. Make turbo repo work with the local server
-```yaml
-- name: Build
-  run: yarn build
-  env:
-    TURBO_API: 'http://127.0.0.1:9080'
-    TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-    TURBO_TEAM: 'foo'
-    TURBO_REMOTE_ONLY: true
-```
+
+   Enable `turbo` remote caching though environment variables.
+
+   ```yaml
+   - name: Build
+     run: yarn build
+     env:
+       TURBO_API: 'http://127.0.0.1:9080'
+       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+       TURBO_TEAM: 'foo'
+   ```
+
 That's it 😋.
 
 ### Action inputs
+
 The action has 1 **required** inputs:
 - `repo-token` - A Github token with `repo` permission, usually the default `secrets.GITHUB_TOKEN` is enough.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This action allows you to use Github artifacts as [TurboRepo](https://github.com
 
 ## How it works?
 
-It's starts a local TurboRepo server (on port `9080`) and uses Github artifacts as a caching storage. 
+It's starts a local TurboRepo server (on port `9080`) and uses Github artifacts as a caching storage.
 
 ## Setup
 
@@ -14,25 +14,28 @@ It's starts a local TurboRepo server (on port `9080`) and uses Github artifacts 
   uses: felixmosh/turborepo-gh-artifacts@v1
   with:
     repo-token: ${{ secrets.GITHUB_TOKEN }}
-    server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
 ```
 2. Make turbo repo work with the local server
 ```yaml
 - name: Build
-  run: yarn build --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="foo"
+  run: yarn build
+  env:
+    TURBO_API: 'http://127.0.0.1:9080'
+    TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+    TURBO_TEAM: 'foo'
+    TURBO_REMOTE_ONLY: true
 ```
 That's it 😋.
 
 ### Action inputs
-The action has 2 **required** inputs:
-1. `repo-token` - A Github token with `repo` permission, usually the default `secrets.GITHUB_TOKEN` is enough.
-2. `server-token` - An auth token to ensure that your code interacting with the local server.
+The action has 1 **required** inputs:
+- `repo-token` - A Github token with `repo` permission, usually the default `secrets.GITHUB_TOKEN` is enough.
 
 Pay ❤️, `GITHUB_TOKEN` must have [`actions: read`](https://docs.github.com/en/rest/reference/actions#get-an-artifact) permissions in order to be able to read repo's existing artifacts.
 
 ## Working Example
 
-[Working example](https://github.com/felixmosh/turborepo-gh-artifacts-example) of the entire setup, based on `npx create-turbo@latest`. 
+[Working example](https://github.com/felixmosh/turborepo-gh-artifacts-example) of the entire setup, based on `npx create-turbo@latest`.
 
 ## Useful Links
 

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: true
   server-token:
     description: 'An access token of the local turbo-server'
-    required: true
+    required: false
 
 runs:
   using: 'node16'

--- a/src/turboServer.ts
+++ b/src/turboServer.ts
@@ -13,7 +13,7 @@ async function startServer() {
   fs.ensureDirSync(cacheDir);
 
   const app = express();
-  const serverToken = getInput(Inputs.SERVER_TOKEN, {
+  const serverToken = process.env.TURBO_TOKEN || getInput(Inputs.SERVER_TOKEN, {
     required: true,
     trimWhitespace: true,
   });
@@ -41,7 +41,9 @@ async function startServer() {
       const filepath = path.join(cacheDir, `${artifactId}.gz`);
 
       if (!fs.pathExistsSync(filepath)) {
-        console.log(`Artifact ${artifactId} not found locally, attempting to download it.`);
+        console.log(
+          `Artifact ${artifactId} not found locally, attempting to download it.`
+        );
 
         if (!artifactList) {
           // Cache the response for the runtime of the server.
@@ -55,7 +57,9 @@ async function startServer() {
 
         if (existingArtifact) {
           if (existingArtifact.expired) {
-            console.log(`Artifact ${artifactId} expired at ${existingArtifact.expires_at}, not downloading.`)
+            console.log(
+              `Artifact ${artifactId} expired at ${existingArtifact.expires_at}, not downloading.`
+            );
           } else {
             console.log(`Artifact ${artifactId} found.`);
             await downloadArtifact(existingArtifact, cacheDir);
@@ -112,5 +116,5 @@ async function startServer() {
 }
 
 startServer().catch((error) => {
-  setFailed(error)
+  setFailed(error);
 });


### PR DESCRIPTION
Using environment variables to initiate TurboRepo into local caching mode creates cleaner `package.json` scripts that are usable in local development and CI.

Fixes #18

**References**

github.com/vercel/turbo [ReadRepoConfigFile](https://github.com/vercel/turbo/blob/658dcadceb227c815d9db0ebdf248e78daf65482/cli/internal/config/config_file.go#L196) source code
github.com/vercel/turbo [Issue #1324](https://github.com/vercel/turbo/issues/1324)