### PR TITLE
Improved error handling

### DIFF
--- a/dist/turboServer/index.js
+++ b/dist/turboServer/index.js
@@ -39005,7 +39005,10 @@ async function startServer() {
     app.get('/v8/artifacts/:artifactId', express_async_handler_default()(async (req, res) => {
         const { artifactId } = req.params;
         const filepath = external_path_default().join(cacheDir, `${artifactId}.gz`);
-        if (!lib_default().pathExistsSync(filepath)) {
+        if (lib_default().pathExistsSync(filepath)) {
+            external_console_namespaceObject.log(`Artifact ${artifactId} found locally.`);
+        }
+        else {
             external_console_namespaceObject.log(`Artifact ${artifactId} not found locally, attempting to download it.`);
             let existingArtifact;
             if (cacheMap.has(artifactId)) {
@@ -39033,20 +39036,17 @@ async function startServer() {
                 }
             }
             if (!lib_default().pathExistsSync(filepath)) {
-                external_console_namespaceObject.log(`Artifact ${artifactId} could not be downloaded.`);
+                external_console_namespaceObject.log(`Artifact ${artifactId} not present.`);
                 return res.status(404).send('Not found');
             }
-        }
-        else {
-            external_console_namespaceObject.log(`Artifact ${artifactId} found locally.`);
         }
         const readStream = lib_default().createReadStream(filepath);
         readStream.on('open', () => {
             readStream.pipe(res);
         });
-        readStream.on('error', (err) => {
-            external_console_namespaceObject.error(err);
-            res.end(err);
+        readStream.on('error', (error) => {
+            external_console_namespaceObject.error(error);
+            res.end(error);
         });
     }));
     app.put('/v8/artifacts/:artifactId', (req, res) => {
@@ -39058,8 +39058,8 @@ async function startServer() {
         lib_default().ensureDirSync(newArtifactsDir);
         const writeStream = lib_default().createWriteStream(external_path_default().join(newArtifactsDir, filename));
         req.pipe(writeStream);
-        writeStream.on('error', (err) => {
-            external_console_namespaceObject.error(err);
+        writeStream.on('error', (error) => {
+            external_console_namespaceObject.error(error);
             res.status(500).send('ERROR');
         });
         req.on('end', () => {

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,7 +1,4 @@
-import {setFailed} from '@actions/core';
-import fs from 'fs-extra';
-import path from 'path';
-import { cacheDir, newArtifactsDirName } from './utils/constants';
+import { setFailed } from '@actions/core';
 import { printServerLogs } from './utils/printServerLogs';
 import { stopServer } from './utils/stopServer';
 import { uploadArtifacts } from './utils/uploadArtifacts';
@@ -9,9 +6,11 @@ import { uploadArtifacts } from './utils/uploadArtifacts';
 async function post() {
   stopServer();
 
-  await uploadArtifacts();
-
-  printServerLogs();
+  try {
+    await uploadArtifacts();
+  } finally {
+    printServerLogs();
+  }
 }
 
 post().catch((error) => {

--- a/src/turboServer.ts
+++ b/src/turboServer.ts
@@ -47,7 +47,9 @@ async function startServer() {
 
       const filepath = path.join(cacheDir, `${artifactId}.gz`);
 
-      if (!fs.pathExistsSync(filepath)) {
+      if (fs.pathExistsSync(filepath)) {
+        console.log(`Artifact ${artifactId} found locally.`);
+      } else {
         console.log(
           `Artifact ${artifactId} not found locally, attempting to download it.`,
         );
@@ -86,11 +88,9 @@ async function startServer() {
         }
 
         if (!fs.pathExistsSync(filepath)) {
-          console.log(`Artifact ${artifactId} could not be downloaded.`);
+          console.log(`Artifact ${artifactId} not present.`);
           return res.status(404).send('Not found');
         }
-      } else {
-        console.log(`Artifact ${artifactId} found locally.`);
       }
 
       const readStream = fs.createReadStream(filepath);
@@ -98,9 +98,9 @@ async function startServer() {
         readStream.pipe(res);
       });
 
-      readStream.on('error', (err) => {
-        console.error(err);
-        res.end(err);
+      readStream.on('error', (error) => {
+        console.error(error);
+        res.end(error);
       });
     }),
   );
@@ -119,8 +119,8 @@ async function startServer() {
 
     req.pipe(writeStream);
 
-    writeStream.on('error', (err) => {
-      console.error(err);
+    writeStream.on('error', (error) => {
+      console.error(error);
       res.status(500).send('ERROR');
     });
 

--- a/src/utils/stopServer.ts
+++ b/src/utils/stopServer.ts
@@ -5,7 +5,7 @@ function pidIsRunning(pid) {
   try {
     process.kill(+pid, 0);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
## Issue

When we switched from version 2 to version 3 the action failed with `Error: dest already exists.`.
This seems to happen because the server reports an artifact as missing to the client while it is present locally.
Unfortunately the server logs are not displayed when an error occurs.

```
# Run 1
Gonna upload 34 artifacts:
Artifact 497c63b8420db137.zip successfully finalized. Artifact ID 1669006810
Uploaded 497c63b8420db137.gz successfully
# Run 2
Gonna upload 3 artifacts:
[
  "219c60ff8f337fd5",
  "497c63b8420db137",
  "a9ec3980ebb0c0a5"
]
Artifact 497c63b8420db137.zip successfully finalized. Artifact ID 1669027416
Uploaded 497c63b8420db137.gz successfully
Error: Error: dest already exists.
```

## Changes

- Don't fail on already existing artifact
- Always print server logs